### PR TITLE
Add transaction & refund REST endpoints

### DIFF
--- a/src/main/java/com/example/paymentservice/controller/dto/RefundDto.java
+++ b/src/main/java/com/example/paymentservice/controller/dto/RefundDto.java
@@ -1,0 +1,17 @@
+package com.example.paymentservice.controller.dto;
+
+import com.example.paymentservice.model.enums.RefundStatus;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Data
+public class RefundDto {
+    private Long id;
+    private Long transactionId;
+    private BigDecimal refundedAmount;
+    private RefundStatus status;
+    private String reason;
+    private OffsetDateTime executedAt;
+}

--- a/src/main/java/com/example/paymentservice/controller/dto/TransactionDto.java
+++ b/src/main/java/com/example/paymentservice/controller/dto/TransactionDto.java
@@ -1,7 +1,20 @@
 package com.example.paymentservice.controller.dto;
 
+import com.example.paymentservice.model.enums.PaymentTransactionStatus;
 import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 
 @Data
 public class TransactionDto {
+    private Long id;
+    private Long sourceCurrencyAccountId;
+    private Long destinationCurrencyAccountId;
+    private BigDecimal amountDebited;
+    private BigDecimal amountCredited;
+    private BigDecimal exchangeRate;
+    private PaymentTransactionStatus status;
+    private String errorMessage;
+    private OffsetDateTime executedAt;
 }

--- a/src/main/java/com/example/paymentservice/controller/rest/CurrencyAccountController.java
+++ b/src/main/java/com/example/paymentservice/controller/rest/CurrencyAccountController.java
@@ -6,10 +6,10 @@ import com.example.paymentservice.controller.dto.CurrencyAccountDto;
 import com.example.paymentservice.service.currency.CurrencyAccountService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.openapitools.model.CurrencyAccountCreate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -27,5 +27,15 @@ public class CurrencyAccountController {
             @RequestParam Long userId
     ) {
         return currencyAccountService.getUserAccounts(userId);
+    }
+
+    @Operation(summary = "Открыть валютный субсчёт")
+    @PostMapping
+    public ResponseEntity<CurrencyAccountDto> createAccount(
+            @RequestParam Long bankAccountId,
+            @RequestBody CurrencyAccountCreate request
+    ) {
+        CurrencyAccountDto dto = currencyAccountService.createAccount(bankAccountId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
     }
 }

--- a/src/main/java/com/example/paymentservice/controller/rest/PaymentTransactionController.java
+++ b/src/main/java/com/example/paymentservice/controller/rest/PaymentTransactionController.java
@@ -1,0 +1,61 @@
+package com.example.paymentservice.controller.rest;
+
+import com.example.paymentservice.controller.dto.RefundDto;
+import com.example.paymentservice.controller.dto.TransactionDto;
+import com.example.paymentservice.controller.dto.kafka.CancelPaymentRequest;
+import com.example.paymentservice.controller.dto.kafka.CreatePaymentTransactionRequest;
+import com.example.paymentservice.mapper.PaymentTransactionMapper;
+import com.example.paymentservice.mapper.RefundMapper;
+import com.example.paymentservice.service.PaymentTransactionService;
+import com.example.paymentservice.service.refund.RefundService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/transactions")
+@RequiredArgsConstructor
+public class PaymentTransactionController {
+    private final PaymentTransactionService paymentTransactionService;
+    private final RefundService refundService;
+    private final PaymentTransactionMapper paymentTransactionMapper;
+    private final RefundMapper refundMapper;
+
+    @PostMapping
+    public ResponseEntity<TransactionDto> createTransaction(@RequestBody CreatePaymentTransactionRequest request) {
+        var transaction = paymentTransactionService.transfer(request);
+        var dto = paymentTransactionMapper.toDto(transaction);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<TransactionDto> getTransaction(@PathVariable Long id) {
+        var transaction = paymentTransactionService.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Transaction not found: " + id));
+        var dto = paymentTransactionMapper.toDto(transaction);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping("/{id}/refund")
+    public ResponseEntity<RefundDto> createRefund(@PathVariable Long id,
+                                                  @RequestBody CancelPaymentRequest request) {
+        request.setTransactionId(id);
+        var refund = refundService.createRefund(request);
+        var dto = refundMapper.toDto(refund);
+        return ResponseEntity.status(HttpStatus.CREATED).body(dto);
+    }
+
+    @GetMapping("/{id}/refunds")
+    public List<RefundDto> getRefunds(@PathVariable Long id) {
+        return refundService.getRefundsForTransaction(id).stream()
+                .map(refundMapper::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/paymentservice/mapper/PaymentTransactionMapper.java
+++ b/src/main/java/com/example/paymentservice/mapper/PaymentTransactionMapper.java
@@ -1,5 +1,6 @@
 package com.example.paymentservice.mapper;
 
+import com.example.paymentservice.controller.dto.TransactionDto;
 import com.example.paymentservice.controller.dto.kafka.CreatePaymentTransactionResponse;
 import com.example.paymentservice.controller.dto.enums.CommandResultStatus;
 import com.example.paymentservice.model.entity.PaymentTransaction;
@@ -20,6 +21,11 @@ public interface PaymentTransactionMapper {
     @Mapping(source = "status", target = "status", qualifiedByName = "mapPaymentTransactionStatusToCommandResultStatus")
     @Mapping(source = "createdAt", target = "executedAt")
     CreatePaymentTransactionResponse toKafkaDto(PaymentTransaction paymentTransaction);
+
+    @Mapping(source = "createdAt", target = "executedAt", qualifiedByName = "mapLocalDateTimeToOffsetDateTime")
+    @Mapping(source = "source.id", target = "sourceCurrencyAccountId")
+    @Mapping(source = "destination.id", target = "destinationCurrencyAccountId")
+    TransactionDto toDto(PaymentTransaction paymentTransaction);
 
     @Named("mapLocalDateTimeToOffsetDateTime")
     default OffsetDateTime mapLocalDateTimeToOffsetDateTime(LocalDateTime localDateTime) {

--- a/src/main/java/com/example/paymentservice/mapper/RefundMapper.java
+++ b/src/main/java/com/example/paymentservice/mapper/RefundMapper.java
@@ -1,5 +1,6 @@
 package com.example.paymentservice.mapper;
 
+import com.example.paymentservice.controller.dto.RefundDto;
 import com.example.paymentservice.controller.dto.kafka.CancelPaymentRequest;
 import com.example.paymentservice.controller.dto.kafka.CancelPaymentResponse;
 import com.example.paymentservice.controller.dto.enums.CommandResultStatus;
@@ -8,6 +9,9 @@ import com.example.paymentservice.model.enums.RefundStatus;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 @Mapper(componentModel = "spring")
 public interface RefundMapper {
@@ -18,6 +22,10 @@ public interface RefundMapper {
     @Mapping(source = "status", target = "status", qualifiedByName = "mapRefundStatusToCommandStatus")
     CancelPaymentResponse toResponse(Refund refund);
 
+    @Mapping(source = "paymentTransaction.id", target = "transactionId")
+    @Mapping(source = "createdAt", target = "executedAt", qualifiedByName = "mapLocalDateTimeToOffsetDateTime")
+    RefundDto toDto(Refund refund);
+
     @Named("mapRefundStatusToCommandStatus")
     default CommandResultStatus mapRefundStatusToCommandStatus(RefundStatus refundStatus) {
         if (refundStatus == null) {
@@ -27,5 +35,10 @@ public interface RefundMapper {
             case COMPLETED -> CommandResultStatus.SUCCESS;
             case FAILED -> CommandResultStatus.FAILED;
         };
+    }
+
+    @Named("mapLocalDateTimeToOffsetDateTime")
+    default OffsetDateTime mapLocalDateTimeToOffsetDateTime(LocalDateTime localDateTime) {
+        return (localDateTime == null) ? null : localDateTime.atOffset(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/example/paymentservice/service/currency/CurrencyAccountService.java
+++ b/src/main/java/com/example/paymentservice/service/currency/CurrencyAccountService.java
@@ -5,6 +5,7 @@ import com.example.paymentservice.controller.dto.CurrencyAccountDto;
 import com.example.paymentservice.mapper.CurrencyAccountMapper;
 import com.example.paymentservice.model.entity.account.BankAccount;
 import com.example.paymentservice.model.entity.account.CurrencyAccount;
+import com.example.paymentservice.repository.BankAccountRepository;
 import com.example.paymentservice.repository.CurrencyAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 public class CurrencyAccountService {
     private final CurrencyAccountRepository currencyAccountRepository;
     private final CurrencyAccountMapper currencyAccountMapper;
+    private final BankAccountRepository bankAccountRepository;
 
     @Transactional
     public List<CurrencyAccountDto> getUserAccounts(Long accountId) {
@@ -79,5 +81,16 @@ public class CurrencyAccountService {
             account.setBankAccount(bankAccount);
         }
         return currencyAccountRepository.saveAll(accounts);
+    }
+
+    @Transactional
+    public CurrencyAccountDto createAccount(Long bankAccountId, CurrencyAccountCreate create) {
+        BankAccount bankAccount = bankAccountRepository.findById(bankAccountId)
+                .orElseThrow(() -> new EntityNotFoundException("Bank account not found: " + bankAccountId));
+
+        CurrencyAccount entity = currencyAccountMapper.toEntity(create);
+        entity.setBankAccount(bankAccount);
+        CurrencyAccount saved = currencyAccountRepository.save(entity);
+        return currencyAccountMapper.toDto(saved);
     }
 }


### PR DESCRIPTION
## Summary
- add DTOs for payment transactions and refunds
- support creation of currency sub-accounts via REST
- implement `/api/v1/transactions` endpoints for create, get and refunds
- expose refund lookup via REST
- extend mappers and services for new functionality

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688133f2013c8329ac8d78822705a745